### PR TITLE
Require Working Drafts; allow combined Sec & Priv sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-a-check-of-a-self-review.md
+++ b/.github/ISSUE_TEMPLATE/request-a-check-of-a-self-review.md
@@ -2,13 +2,13 @@
 name: Request a check of a self-review
 about: If you have completed a self-review, use this form to request that PING check
   it out.
-title: Spec_name 2021-mm-dd
+title: Spec_name 2022-mm-dd
 labels: REVIEW REQUESTED, SR, pending
 assignees: ''
 
 ---
 
-We have conducted a self-review of our spec [SPEC_NAME_HERE](URL_GOES_HERE), and the results can be found at URL_FOR_THE_ISSUE_IN_YOUR_REPO.
+We have conducted a self-review of our spec [SPEC_NAME_HERE](URL_GOES_HERE) [This must be a dated version in the TR namespace, not an editors draft.] , and the results can be found at URL_FOR_THE_ISSUE_IN_YOUR_REPO.
 
 Please check our findings.
 

--- a/.github/ISSUE_TEMPLATE/request-a-check-of-a-self-review.md
+++ b/.github/ISSUE_TEMPLATE/request-a-check-of-a-self-review.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ---
 
-We have conducted a self-review of our spec [SPEC_NAME_HERE](URL_GOES_HERE) [This must be a dated version in the TR namespace, not an editors draft.] , and the results can be found at URL_FOR_THE_ISSUE_IN_YOUR_REPO.
+We have conducted a self-review of our spec [SPEC_NAME_HERE](URL_GOES_HERE) [This must be a dated version in the TR namespace, not an editor's draft.] , and the results can be found at URL_FOR_THE_ISSUE_IN_YOUR_REPO.
 
 Please check our findings.
 

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.md
@@ -1,7 +1,7 @@
 ---
 name: Request review for a FPWD
 about: Use this if you are approaching or have just passed FPWD.
-title: Document_name 2021-mm-dd
+title: Document_name 2022-mm-dd
 labels: FPWD, REVIEW REQUESTED, pending
 assignees: ''
 
@@ -14,8 +14,8 @@ If you still want us to review your spec, please provide the information below.
 In the issue title above add the document name followed by the date of this request.
 
 - name of spec to be reviewed:
-- URL of spec:
-- Does your document have an in-line Privacy Considerations section, separate from Security Considerations?  If not, correct that before proceeding further.
+- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
+- Does your document have an in-line Privacy Considerations section, ideally one separate from Security Considerations?  If not, correct that before proceeding further.
 - Do you need a reply by a particular date?
 - Please point to the results of your own self-review (see https://w3ctag.github.io/security-questionnaire/ , https://w3c.github.io/fingerprinting-guidance/, https://tools.ietf.org/html/rfc6973)
 - Where and how to file issues arising?

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-fpwd.md
@@ -14,7 +14,7 @@ If you still want us to review your spec, please provide the information below.
 In the issue title above add the document name followed by the date of this request.
 
 - name of spec to be reviewed:
-- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
+- URL of spec: [This must be a dated version in the TR namespace, not an editor's draft.]
 - Does your document have an in-line Privacy Considerations section, ideally one separate from Security Considerations?  If not, correct that before proceeding further.
 - Do you need a reply by a particular date?
 - Please point to the results of your own self-review (see https://w3ctag.github.io/security-questionnaire/ , https://w3c.github.io/fingerprinting-guidance/, https://tools.ietf.org/html/rfc6973)

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-spec-in-cr.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-spec-in-cr.md
@@ -1,7 +1,7 @@
 ---
 name: Request review for a spec in CR
 about: If your spec is already in CR, use this form.
-title: Document_name 2021-mm-dd > 2021-mm-dd
+title: Document_name 2022-mm-dd > 2022-mm-dd
 labels: CR, REVIEW REQUESTED, pending
 assignees: ''
 
@@ -10,11 +10,11 @@ assignees: ''
 In the issue title above add the document name followed by the date of this request, then the date of your proposed deadline for comments.
 
 - name of spec to be reviewed:
-- URL of spec:
+- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
 
 - What and when is your next expected transition?
 - What has changed since any previous review?
-- Does your document have an in-line Privacy Considerations section, separate from Security Considerations?  If not, corrrect that before proceeding further.
+- Does your document have an in-line Privacy Considerations section, ideally one separate from the Security Considerations?  If not, corrrect that before proceeding further.
 - Please point to the results of your own self-review (see https://w3ctag.github.io/security-questionnaire/ , https://w3c.github.io/fingerprinting-guidance/, https://tools.ietf.org/html/rfc6973)
 - Where and how to file issues arising?
 - Pointer to any explainer for the spec?

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-spec-in-cr.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-spec-in-cr.md
@@ -10,7 +10,7 @@ assignees: ''
 In the issue title above add the document name followed by the date of this request, then the date of your proposed deadline for comments.
 
 - name of spec to be reviewed:
-- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
+- URL of spec: [This must be a dated version in the TR namespace, not an editor's draft.]
 
 - What and when is your next expected transition?
 - What has changed since any previous review?

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-wd-that-is-moving-to-cr-soon.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-wd-that-is-moving-to-cr-soon.md
@@ -1,7 +1,7 @@
 ---
 name: Request review for a WD that is moving to CR soon
 about: Use this if you have a transition date coming up, and need to get a final review.
-title: Document_name 2021-mm-dd > 2021-mm-dd
+title: Document_name 2022-mm-dd > 2022-mm-dd
 labels: LC, REVIEW REQUESTED, pending
 assignees: ''
 
@@ -10,11 +10,11 @@ assignees: ''
 In the issue title above add the document name followed by the date of this request, then the date of your proposed deadline for comments.
 
 - name of spec to be reviewed:
-- URL of spec:
+- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
 
 - What and when is your next expected transition?
 - What has changed since any previous review?
-- Does your document have an in-line Privacy Considerations section, separate from Security Considerations?  If not, corrrect that before proceeding further.
+- Does your document have an in-line Privacy Considerations section, ideally one separate from Security Considerations?  If not, corrrect that before proceeding further.
 - Please point to the results of your own self-review (see https://w3ctag.github.io/security-questionnaire/ , https://w3c.github.io/fingerprinting-guidance/, https://tools.ietf.org/html/rfc6973)
 - Where and how to file issues arising?
 - Pointer to any explainer for the spec?

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-wd-that-is-moving-to-cr-soon.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-wd-that-is-moving-to-cr-soon.md
@@ -14,7 +14,7 @@ In the issue title above add the document name followed by the date of this requ
 
 - What and when is your next expected transition?
 - What has changed since any previous review?
-- Does your document have an in-line Privacy Considerations section, ideally one separate from Security Considerations?  If not, corrrect that before proceeding further.
+- Does your document have an in-line Privacy Considerations section, ideally one separate from the Security Considerations?  If not, corrrect that before proceeding further.
 - Please point to the results of your own self-review (see https://w3ctag.github.io/security-questionnaire/ , https://w3c.github.io/fingerprinting-guidance/, https://tools.ietf.org/html/rfc6973)
 - Where and how to file issues arising?
 - Pointer to any explainer for the spec?

--- a/.github/ISSUE_TEMPLATE/request-review-for-a-wd-that-is-moving-to-cr-soon.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-a-wd-that-is-moving-to-cr-soon.md
@@ -10,7 +10,7 @@ assignees: ''
 In the issue title above add the document name followed by the date of this request, then the date of your proposed deadline for comments.
 
 - name of spec to be reviewed:
-- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
+- URL of spec: [This must be a dated version in the TR namespace, not an editor's draft.]
 
 - What and when is your next expected transition?
 - What has changed since any previous review?

--- a/.github/ISSUE_TEMPLATE/request-review-for-another-type-of-spec.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-another-type-of-spec.md
@@ -10,7 +10,7 @@ assignees: ''
 In the issue title above add the document name followed by the date of this request, then the date of your proposed deadline for comments.
 
 - name of spec to be reviewed:
-- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
+- URL of spec: [This must be a dated version in the TR namespace, not an editor's draft.]
 
 - Current Rec/Note phase?
 - What and when is your next expected transition?

--- a/.github/ISSUE_TEMPLATE/request-review-for-another-type-of-spec.md
+++ b/.github/ISSUE_TEMPLATE/request-review-for-another-type-of-spec.md
@@ -1,7 +1,7 @@
 ---
 name: Request review for another type of spec
 about: If your spec doesn't fit one of the other options, use this.
-title: Document_name 2021-mm-dd > 2021-mm-dd
+title: Document_name 2022-mm-dd > 2022-mm-dd
 labels: REVIEW REQUESTED, WD, pending
 assignees: ''
 
@@ -10,7 +10,7 @@ assignees: ''
 In the issue title above add the document name followed by the date of this request, then the date of your proposed deadline for comments.
 
 - name of spec to be reviewed:
-- URL of spec:
+- URL of spec: [This must be a dated version in the TR namespace, not an editors draft.]
 
 - Current Rec/Note phase?
 - What and when is your next expected transition?


### PR DESCRIPTION
Three changes:

* require documents to be reviewed have stable snapshots (not editors drafts)
* Encourage separate privacy considerations sections, but allow combined
* Update dates